### PR TITLE
chore(renovate): use dargmuesli's configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "github>dargmuesli/renovate-config"
   ]
 }


### PR DESCRIPTION
The default renovate configuration can be quite noisy. This is the configuration I use in all my projects: https://github.com/dargmuesli/renovate-config/blob/ae9f8a700016fabc8e382512a604df613f4740be/default.json