### PR TITLE
ci: add dockerized pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Sentry Config File
+.env.sentry-build-plugin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - alpha
+      - beta
+      - master
+      - renovate/**
+
+jobs:
+  prepare_jobs:
+    name: "Prepare: job optimization"
+    runs-on: ubuntu-latest
+    outputs:
+      pr_found: ${{ steps.pr.outputs.pr_found }}
+    steps:
+      - name: Get current PR
+        id: pr
+        uses: 8BitJonny/gh-get-current-pr@3.0.0
+        with:
+          filterOutClosed: true
+          sha: ${{ github.event.pull_request.head.sha }}
+  # release_semantic_dry:
+  #   needs: prepare_jobs
+  #   name: Release (semantic, dry)
+  #   uses: dargmuesli/github-actions/.github/workflows/release-semantic.yml@2.3.5
+  #   if: needs.prepare_jobs.outputs.pr_found == 'false' || github.event_name == 'pull_request'
+  #   permissions:
+  #     contents: write
+  #   secrets:
+  #     PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+  #   with:
+  #     DRY_RUN: true
+  build:
+    name: Build
+    uses: dargmuesli/github-actions/.github/workflows/docker.yml@2.3.5
+    needs: prepare_jobs
+    if: needs.prepare_jobs.outputs.pr_found == 'false' || github.event_name == 'pull_request'
+  #   needs: release_semantic_dry
+  #   permissions:
+  #     packages: write
+    with:
+      PUSH: false
+  #     BUILD_ARGUMENTS: RELEASE_NAME=${{ needs.release_semantic_dry.outputs.new_release_version }}
+  #     TAG: ${{ needs.release_semantic_dry.outputs.new_release_version }}
+  # release_semantic:
+  #   needs: build
+  #   name: Release (semantic)
+  #   uses: dargmuesli/github-actions/.github/workflows/release-semantic.yml@2.3.5
+  #   permissions:
+  #     contents: write
+  #   secrets:
+  #     PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,228 @@
+#############
+# Create base image.
+
+FROM node:22.11.0-alpine AS base-image
+
+# # The `CI` environment variable must be set for pnpm to run in headless mode
+# ENV CI=true
+
+WORKDIR /srv/app/
+
+RUN apk update \
+    && apk add --no-cache git \
+    && corepack enable
+
+
+#############
+# Development container image.
+
+FROM base-image AS development
+
+# COPY ./docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+# VOLUME /srv/.pnpm-store
+VOLUME /srv/app
+
+USER node
+
+# ENTRYPOINT ["docker-entrypoint.sh"]
+# CMD ["pnpm", "run", "--dir", "src", "dev", "--host"]
+CMD ["npm", "run", "dev", "--port", "3000"]
+EXPOSE 3000
+
+# HEALTHCHECK --interval=10s CMD wget -O /dev/null http://localhost:3000/api/healthcheck || exit 1
+
+
+########################
+# Prepare ci.
+
+FROM base-image AS prepare
+
+# COPY ./pnpm-lock.yaml ./
+COPY ./package.json ./package-lock.json ./
+
+# RUN pnpm fetch
+RUN npm install
+
+COPY ./ ./
+
+# RUN pnpm install --offline
+
+
+# ########################
+# # Build for Node deployment.
+
+# FROM prepare AS build-node
+
+# # ARG RELEASE_NAME
+# # ENV RELEASE_NAME=${RELEASE_NAME}
+# # ARG SENTRY_AUTH_TOKEN
+# # ENV SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
+
+# ENV NODE_ENV=production
+# RUN npm run build
+# # RUN pnpm --dir src run build:node
+
+
+########################
+# Build for static deployment.
+
+FROM prepare AS build-static
+
+# ARG SITE_URL=http://localhost:3002
+# ENV SITE_URL=${SITE_URL}
+
+ENV NODE_ENV=production
+RUN npm run build
+# RUN pnpm --dir src run build:static
+
+
+########################
+# Nuxt: lint
+
+FROM prepare AS lint
+
+RUN npm run lint
+# RUN pnpm -r run lint
+
+
+# ########################
+# # Nuxt: test (unit)
+
+# FROM prepare AS test-unit
+
+# RUN pnpm -r run test
+
+
+# ########################
+# # Nuxt: test (e2e, base-image)
+
+# FROM mcr.microsoft.com/playwright:v1.49.0 AS test-e2e-base-image
+
+# # The `CI` environment variable must be set for pnpm to run in headless mode
+# ENV CI=true
+# ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
+# WORKDIR /srv/app/
+
+# RUN corepack enable
+
+
+# ########################
+# # Nuxt: test (e2e)
+
+# FROM test-e2e-base-image AS test-e2e_development
+
+# ARG UNAME=e2e
+# ARG UID=1000
+# ARG GID=1000
+
+# ENV NODE_ENV=development
+
+# COPY ./docker-entrypoint.sh /usr/local/bin/
+
+# RUN groupadd -g $GID -o $UNAME \
+#     && useradd -m -l -u $UID -g $GID -o -s /bin/bash $UNAME
+
+# USER $UNAME
+
+# VOLUME /srv/.pnpm-store
+# VOLUME /srv/app
+
+# ENTRYPOINT ["docker-entrypoint.sh"]
+
+
+# ########################
+# # Nuxt: test (e2e, preparation)
+
+# FROM test-e2e-base-image AS test-e2e-prepare
+
+# COPY --from=prepare /srv/app/ ./
+
+# RUN pnpm -r rebuild
+
+
+# ########################
+# # Nuxt: test (e2e, development)
+
+# FROM test-e2e-prepare AS test-e2e-dev
+
+# ENV NODE_ENV=development
+
+# RUN pnpm --dir tests run test:e2e:server:dev
+
+
+# ########################
+# # Nuxt: test (e2e, node)
+
+# FROM test-e2e-prepare AS test-e2e-node
+
+# COPY --from=build-node /srv/app/src/.output ./src/.output
+
+# RUN pnpm --dir tests run test:e2e:server:node
+
+
+# ########################
+# # Nuxt: test (e2e, static)
+
+# FROM test-e2e-prepare AS test-e2e-static
+
+# COPY --from=build-static /srv/app/src/.output/public ./src/.output/public
+
+# RUN pnpm --dir tests run test:e2e:server:static
+
+
+#######################
+# Collect build, lint and test results.
+
+FROM base-image AS collect
+
+# COPY --from=build-node /srv/app/src/.output ./.output
+# COPY --from=build-node /srv/app/src/package.json ./package.json
+COPY --from=build-static /srv/app/dist ./dist
+COPY --from=lint /srv/app/package.json /tmp/package.json
+# COPY --from=test-unit /srv/app/package.json /tmp/package.json
+# COPY --from=test-e2e-dev /srv/app/package.json /tmp/package.json
+# COPY --from=test-e2e-node /srv/app/package.json /tmp/package.json
+# COPY --from=test-e2e-static /srv/app/package.json /tmp/package.json
+
+
+#######################
+# Provide a web server.
+
+FROM nginx:1.27.2-alpine AS production
+
+# The `CI` environment variable must be set for pnpm to run in headless mode
+ENV CI=true
+ENV NODE_ENV=production
+
+WORKDIR /usr/share/nginx/html
+
+# COPY ./docker/nginx.conf /etc/nginx/nginx.conf
+
+COPY --from=collect /srv/app/dist/ ./
+
+# HEALTHCHECK --interval=10s CMD wget -O /dev/null http://localhost:3000/api/healthcheck || exit 1
+EXPOSE 80
+LABEL org.opencontainers.image.source="https://github.com/flipdot/app-dashboard"
+LABEL org.opencontainers.image.description="https://apps.flipdot.org"
+
+
+# #######################
+# # Provide a web server.
+# # Requires node (cannot be static) as the server acts as backend too.
+
+# FROM collect AS production
+
+# ENV NODE_ENV=production
+
+# # Update dependencies.
+# RUN apk update \
+#     && apk upgrade --no-cache
+
+# ENTRYPOINT ["pnpm"]
+# CMD ["run", "start:node"]
+# HEALTHCHECK --interval=10s CMD wget -O /dev/null http://localhost:3000/api/healthcheck || exit 1
+# EXPOSE 3000
+# LABEL org.opencontainers.image.source="https://github.com/maevsi/maevsi"
+# LABEL org.opencontainers.image.description="Find events, guests and friends 💙❤️💚"


### PR DESCRIPTION
I propose adding a ci pipeline that runs the build and lint scripts which allows renovate to merge update branches automatically. I usually add a multistage Dockerfile as pipeline definition to stay as flexible as possible in regard to the Git hosting solution.

I've left many commented lines in the current definition that we can use for further pipeline optimizations in the future, that we can discuss in person @soerface.